### PR TITLE
smaller fo

### DIFF
--- a/fo/Dockerfile
+++ b/fo/Dockerfile
@@ -1,6 +1,6 @@
-FROM amazoncorretto:17 as build
+FROM eclipse-temurin:17-jre-alpine AS build
 WORKDIR /workdir
-RUN yum install -y unzip curl
+RUN apk add curl unzip bash
 
 # install leiningen
 ADD https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein /usr/bin/
@@ -8,9 +8,8 @@ RUN chmod +x /usr/bin/lein
 
 # cache deps before build
 RUN curl -fSL https://github.com/ahxxm/fo/archive/refs/heads/master.zip --output master.zip && unzip master.zip && mv fo-master/* ./
-RUN lein deps
-RUN lein uberjar
+RUN lein deps && lein uberjar && rm -rf ~/.m2
 
 # runner
-FROM amazoncorretto:17
+FROM eclipse-temurin:17-jre-alpine
 COPY --from=build /workdir/target/fo-0.1.0-SNAPSHOT-standalone.jar /fo.jar


### PR DESCRIPTION
this reduced image size from 404M(370M base + 34M uberjar) to 200M

and triggers a rebuild after dep bump